### PR TITLE
Get interp with n-grams ordering working

### DIFF
--- a/interp-simplified-dynamic.scm
+++ b/interp-simplified-dynamic.scm
@@ -44,22 +44,22 @@
   (fresh (rator x* rands body env^ a* res)
     (== `(,rator . ,rands) expr)
     ;; Multi-argument
-    (eval-expo rator env `(closure (lambda ,x* ,body) ,env^))
-    (eval-listo rands env a*)
+    (eval-expo rator env `(closure (lambda ,x* ,body) ,env^) 'app-rator)
+    (eval-randso rands env a*)
     (ext-env*o x* a* env^ res)
-    (eval-expo body res val)))
+    (eval-expo body res val 'lambda)))
 
 (define (car-evalo expr env val)
   (fresh (e d)
     (== `(car ,e) expr)
     (=/= 'closure val)
-    (eval-expo e env `(,val . ,d))))
+    (eval-expo e env `(,val . ,d) 'car)))
 
 (define (cdr-evalo expr env val)
   (fresh (e a)
     (== `(cdr ,e) expr)
     (=/= 'closure a)
-    (eval-expo e env `(,a . ,val))))
+    (eval-expo e env `(,a . ,val) 'cdr)))
 
 (define (null?-evalo expr env val)
   (fresh (e v)
@@ -67,22 +67,22 @@
     (conde
       ((== '() v) (== #t val))
       ((=/= '() v) (== #f val)))
-    (eval-expo e env v)))
+    (eval-expo e env v 'null?)))
 
 (define (cons-evalo expr env val)
   (fresh (e1 e2 v1 v2)
     (== `(cons ,e1 ,e2) expr)
     (== `(,v1 . ,v2) val)
-    (eval-expo e1 env v1)
-    (eval-expo e2 env v2)))
+    (eval-expo e1 env v1 'cons-e1)
+    (eval-expo e2 env v2 'cons-e2)))
 
 (define (if-evalo expr env val)
   (fresh (e1 e2 e3 t)
     (== `(if ,e1 ,e2 ,e3) expr)
-    (eval-expo e1 env t)
+    (eval-expo e1 env t 'if-test)
     (conde
-      ((=/= #f t) (eval-expo e2 env val))
-      ((== #f t) (eval-expo e3 env val)))))
+      ((=/= #f t) (eval-expo e2 env val 'if-conseq))
+      ((== #f t) (eval-expo e3 env val 'if-alt)))))
 
 (define (equal?-evalo expr env val)
   (fresh (e1 e2 v1 v2)
@@ -90,8 +90,8 @@
     (conde
       ((== v1 v2) (== #t val))
       ((=/= v1 v2) (== #f val)))
-    (eval-expo e1 env v1)
-    (eval-expo e2 env v2)))
+    (eval-expo e1 env v1 'equal?-e1)
+    (eval-expo e2 env v2 'equal?-e2)))
 
 (define (and-evalo expr env val)
   (fresh (e*)
@@ -115,7 +115,7 @@
     (conde
       ((symbolo v) (== #t val))
       ((not-symbolo v) (== #f val)))
-    (eval-expo e env v)))
+    (eval-expo e env v 'symbol?)))
 
 (define (not-evalo expr env val)
   (fresh (e v)
@@ -123,7 +123,7 @@
     (conde
       ((=/= #f v) (== #f val))
       ((== #f v) (== #t val)))
-    (eval-expo e env v)))
+    (eval-expo e env v 'not)))
 
 (define (letrec-evalo expr env val)
   (fresh (p-name x body letrec-body)
@@ -134,7 +134,8 @@
     (list-of-symbolso x)
     (eval-expo letrec-body
                `((,p-name . (rec . (lambda ,x ,body))) . ,env)
-               val)))
+               val
+               'letrec-body)))
 
 
 
@@ -151,6 +152,16 @@
       ((=/= x y)
        (lookupo x rest t)))))
 
+(define (eval-randso expr env val)
+  (conde
+    ((== '() expr)
+     (== '() val))
+    ((fresh (a d v-a v-d)
+       (== `(,a . ,d) expr)
+       (== `(,v-a . ,v-d) val)
+       (eval-expo a env v-a 'app-rand*)
+       (eval-randso d env v-d)))))
+
 (define (eval-listo expr env val)
   (conde
     ((== '() expr)
@@ -158,7 +169,7 @@
     ((fresh (a d v-a v-d)
        (== `(,a . ,d) expr)
        (== `(,v-a . ,v-d) val)
-       (eval-expo a env v-a)
+       (eval-expo a env v-a 'list)
        (eval-listo d env v-d)))))
 
 ;; need to make sure lambdas are well formed.
@@ -186,15 +197,15 @@
     ((== '() e*) (== #t val))
     ((fresh (e)
        (== `(,e) e*)
-       (eval-expo e env val)))
+       (eval-expo e env val 'and)))
     ((fresh (e1 e2 e-rest v)
        (== `(,e1 ,e2 . ,e-rest) e*)
        (conde
          ((== #f v)
           (== #f val)
-          (eval-expo e1 env v))
+          (eval-expo e1 env v 'and))
          ((=/= #f v)
-          (eval-expo e1 env v)
+          (eval-expo e1 env v 'and)
           (ando `(,e2 . ,e-rest) env val)))))))
 
 (define (oro e* env val)
@@ -202,15 +213,15 @@
     ((== '() e*) (== #f val))
     ((fresh (e)
        (== `(,e) e*)
-       (eval-expo e env val)))
+       (eval-expo e env val 'or)))
     ((fresh (e1 e2 e-rest v)
        (== `(,e1 ,e2 . ,e-rest) e*)
        (conde
          ((=/= #f v)
           (== v val)
-          (eval-expo e1 env v))
+          (eval-expo e1 env v 'or))
          ((== #f v)
-          (eval-expo e1 env v)
+          (eval-expo e1 env v 'or)
           (oro `(,e2 . ,e-rest) env val)))))))
 
 
@@ -221,7 +232,7 @@
   (lambda  (expr env val)
     (fresh (against-expr mval clause clauses)
       (== `(match ,against-expr ,clause . ,clauses) expr)
-      (eval-expo against-expr env mval)
+      (eval-expo against-expr env mval 'match-against)
       (match-clauses mval `(,clause . ,clauses) env val))))
 
 (define (not-symbolo t)
@@ -274,7 +285,7 @@
       ((fresh (env^)
          (p-match p mval '() penv)
          (regular-env-appendo penv env env^)
-         (eval-expo result-expr env^ val)))
+         (eval-expo result-expr env^ val 'match-body)))
       ((p-no-match p mval '() penv)
        (match-clauses mval d env val)))))
 
@@ -389,7 +400,7 @@
 (define empty-env '())
 
 (define (evalo expr val)
-  (eval-expo expr empty-env val))
+  (eval-expo expr empty-env val 'top-level))
 
 (define (alist-ref alist element failure-result)
   (let ([pr (assoc element alist)])
@@ -456,20 +467,49 @@
     (cond
       [(assoc context orderings-alist) => cdr]
       [else
-        (error 'eval-expo "bad context")])))
+        ;(error 'eval-expo (string-append "bad context " (symbol->string context)))
+
+        ; symbol? doesn't appear in the data, so we'll return the expert ordering
+        ; for such cases.
+        expert-ordering])))
 
 (define (eval-expo expr env val context)
+  ; for debugging build-and-run-code
+
+  ;(conde
+    ;((quote-evalo expr env val))
+    ;((num-evalo expr env val))
+    ;((bool-evalo expr env val))
+    ;((var-evalo expr env val))
+    ;((lambda-evalo expr env val))
+    ;((app-evalo expr env val))
+    ;((car-evalo expr env val))
+    ;((cdr-evalo expr env val))
+    ;((null?-evalo expr env val))
+    ;((cons-evalo expr env val))
+    ;((if-evalo expr env val))
+    ;((equal?-evalo expr env val))
+    ;((and-evalo expr env val))
+    ;((or-evalo expr env val))
+    ;((list-evalo expr env val))
+    ;((symbol?-evalo expr env val))
+    ;((not-evalo expr env val))
+    ;((letrec-evalo expr env val))
+    ;((match-evalo expr env val)))
+
   (build-and-run-conde expr env val
-                       ;(order-eval-relations context)
-                       expert-ordering
+                       (order-eval-relations context)
+                       ;expert-ordering
                        ))
 
 (define build-and-run-conde
   (lambda (expr env val list-of-eval-relations)
-    (lambda (st)
-      (let loop ([list-of-eval-relations list-of-eval-relations])
-        (cond
-          [(null? list-of-eval-relations) (mzero)]
-          [else
-            (mplus (((car list-of-eval-relations) expr env val) st)
-                   (inc (loop (cdr list-of-eval-relations))))])))))
+    (lambdag@ (st)
+              (inc (bind (state-depth-deepen (state-with-scope st (new-scope)))
+                         (lambdag@ (st)
+                                   (let loop ([list-of-eval-relations list-of-eval-relations])
+                                     (cond
+                                       [(null? list-of-eval-relations) (mzero)]
+                                       [else
+                                         (mplus (((car list-of-eval-relations) expr env val) st)
+                                                (inc (loop (cdr list-of-eval-relations))))]))))))))

--- a/n-grams.scm
+++ b/n-grams.scm
@@ -36,12 +36,13 @@
                        [(eqv? x defn-name) (list 'var parent)]
                        [(memv x args) (list 'var parent)]
                        [else (list 'var parent)]))]
+                  ; because our interpreter doesn't support define, code as letrec
                   [(define ,id ,e) (guard (symbol? id))
-                   (cons (list 'define parent) (bigrams-for-expr e 'define id args))]
+                   (cons (list 'letrec parent) (bigrams-for-expr e 'letrec-rhs id args))]
                   [(lambda ,x ,body)
                    (cons (list 'lambda parent)
                          (bigrams-for-expr body
-                                           (if (symbol? x) 'lambda-variadic 'lambda-multi)
+                                           'lambda
                                            defn-name
                                            (if (symbol? x) (list x) x)))]
                   [(if ,test ,conseq ,alt)

--- a/n-grams.scm
+++ b/n-grams.scm
@@ -52,10 +52,10 @@
                                  (bigrams-for-expr alt 'if-alt defn-name args)))]
                   [(symbol? ,e)
                    (cons (list 'symbol? parent)
-                         (bigrams-for-expr e 'prim-op defn-name args))]
+                         (bigrams-for-expr e 'symbol? defn-name args))]
                   [(not ,e)
                    (cons (list 'not parent)
-                         (bigrams-for-expr e 'prim-op defn-name args))]
+                         (bigrams-for-expr e 'not defn-name args))]
                   [(and . ,e*)
                    (cons (list 'and parent)
                          (apply append (map (lambda (e) (bigrams-for-expr e 'and defn-name args)) e*)))]
@@ -67,24 +67,24 @@
                          (apply append (map (lambda (e) (bigrams-for-expr e 'list defn-name args)) e*)))]
                   [(null? ,e)
                    (cons (list 'null? parent)
-                         (bigrams-for-expr e 'prim-op defn-name args))]
+                         (bigrams-for-expr e 'null? defn-name args))]
                   [(pair? ,e)
                    (cons (list 'pair? parent)
-                         (bigrams-for-expr e 'prim-op defn-name args))]
+                         (bigrams-for-expr e 'pair? defn-name args))]
                   [(car ,e)
                    (cons (list 'car parent)
-                         (bigrams-for-expr e 'prim-op defn-name args))]
+                         (bigrams-for-expr e 'car defn-name args))]
                   [(cdr ,e)
                    (cons (list 'cdr parent)
-                         (bigrams-for-expr e 'prim-op defn-name args))]
+                         (bigrams-for-expr e 'cdr defn-name args))]
                   [(cons ,e1 ,e2)
                    (cons (list 'cons parent)
-                         (append (bigrams-for-expr e1 'prim-op defn-name args)
-                                 (bigrams-for-expr e2 'prim-op defn-name args)))]
+                         (append (bigrams-for-expr e1 'cons-e1 defn-name args)
+                                 (bigrams-for-expr e2 'cons-e2 defn-name args)))]
                   [(equal? ,e1 ,e2)
                    (cons (list 'equal? parent)
-                         (append (bigrams-for-expr e1 'prim-op defn-name args)
-                                 (bigrams-for-expr e2 'prim-op defn-name args)))]
+                         (append (bigrams-for-expr e1 'equal?-e1 defn-name args)
+                                 (bigrams-for-expr e2 'equal?-e2 defn-name args)))]
                   [(let ,binding* ,e)
                    (cons (list 'let parent)
                          (append (apply append (map (lambda (binding) (bigrams-for-expr (cadr binding) 'let-rhs defn-name args)) binding*))

--- a/simplified-interp-tests.scm
+++ b/simplified-interp-tests.scm
@@ -48,7 +48,10 @@
                  ((car '((a b c) . _.0)) (absento (closure _.0) (prim _.0))))
                 ;;
                 (('(a b c))
-                 (((lambda _.0 '(a b c))) (=/= ((_.0 quote))) (sym _.0)))))))   
+                 (((lambda _.0 '(a b c))) (=/= ((_.0 quote))) (sym _.0)))
+                ;;
+                (((cdr '(_.0 a b c)) (absento (closure _.0) (prim _.0)))
+                 ((car '((a b c) . _.0)) (absento (closure _.0) (prim _.0))))))))   
         #t)
 
  (test "append-3"
@@ -159,19 +162,25 @@
    #t)
 
  (test "append-11"
-        (run 4 (q)
-          (evalo
-           `(letrec ((append
-                      (lambda (l s)
-                        (if ,q
-                            s
-                            (cons (car l) (append (cdr l) s))))))
-              (append '(a b c) '(d e)))
-           '(a b c d e)))
-        '(((null? l))
-          (((lambda () (null? l))))
-          ((null? ((lambda () l))))
-          ((equal? '() l))))
+        (andmap
+          (lambda (res)
+            (not (not (member res
+                              '(((null? l))
+                                (((lambda () (null? l))))
+                                ((null? ((lambda () l))))
+                                ((equal? '() l))
+                                ((and (null? l)))
+                                ((and (null? l) (quote _.0)) (=/= ((_.0 #f))) (absento (closure _.0) (prim _.0))))))))
+          (run 4 (q)
+               (evalo
+                 `(letrec ((append
+                             (lambda (l s)
+                               (if ,q
+                                 s
+                                 (cons (car l) (append (cdr l) s))))))
+                    (append '(a b c) '(d e)))
+                 '(a b c d e))))
+        #t)
 
 ;; slooow--didnt complete in 30 seconds
 
@@ -190,7 +199,7 @@
                             (cons (car l) (append (cdr l) s))))))
               (append '(a b c) '(d e)))
            '(a b c d e)))
-        '(((null? l) s)))
+        '((((null? l) s))))
 
  (test "append-13"
         (run 1 (q r)
@@ -213,7 +222,7 @@
            '(()
              (a b)
              (c d e f))))
-        '(((null? l) s)))
+        '((((null? l) s))))
 
  (test "append-14"
         (run 1 (q r s)
@@ -236,7 +245,7 @@
            '(()
              (a b)
              (c d e f))))
-        '(((null? l) s cons)))
+        '((((null? l) s cons))))
 
 ;; and tests
  (test "and-0"

--- a/simplified-interp-tests.scm
+++ b/simplified-interp-tests.scm
@@ -633,3 +633,5 @@
     (list '(((lambda (x) `(,x ',x)) '(lambda (x) `(,x ',x))))))
  
  )
+
+(exit)

--- a/test-variants.scm
+++ b/test-variants.scm
@@ -6,6 +6,7 @@
 
 (system "scheme mk-vicare.scm mk.scm test-check.scm interp-old-style.scm simplified-interp-tests.scm")
 
+(exit)
 
 #|
 (define evalo-files '("interp-simplified.scm" "interp-old-style.scm" "interp-old-style-with-list-as-prim.scm"))

--- a/test-variants.scm
+++ b/test-variants.scm
@@ -1,9 +1,10 @@
 ;; Run benchmarks for different interpreters
 
+(system "scheme mk-vicare.scm mk.scm test-check.scm interp-simplified-dynamic.scm simplified-interp-tests.scm")
+
 (system "scheme mk-vicare.scm mk.scm test-check.scm interp-simplified.scm simplified-interp-tests.scm")
 
 (system "scheme mk-vicare.scm mk.scm test-check.scm interp-old-style.scm simplified-interp-tests.scm")
-
 
 
 #|


### PR DESCRIPTION
It's faster: append-12 and append-13 succeed, which time out with the expert-ordering version. Still times out on append-14.